### PR TITLE
feat: 辞書検索APIの実装

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,0 +1,7 @@
+# Gemini API settings
+GEMINI_API_KEY=your_gemini_api_key
+
+# Optional settings (defaults shown)
+GEMINI_MODEL=gemini-1.5-flash
+GEMINI_TIMEOUT_SECONDS=10
+GEMINI_PARALLELISM=5

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -16,6 +16,7 @@ cd Backend
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+cp .env.example .env
 ```
 
 ## 起動

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -87,6 +87,27 @@ make up-backend
     }
     ```
 
+- `POST /dictionary/lookup`
+  - 用語の意味を日本語で1〜2文の概要として返す
+  - 現在は単語DB未実装のため、常にGeminiで生成する
+  - リクエスト例:
+    ```json
+    {
+      "term": "RAG",
+      "context": "LLMの会話で出てきた用語"
+    }
+    ```
+  - レスポンス例:
+    ```json
+    {
+      "term": "RAG",
+      "summary": "RAGは、回答生成時に外部知識を検索して根拠を補う手法です。LLMの回答精度を高める目的で使われます。",
+      "source": "gemini",
+      "model": "gemini-1.5-flash",
+      "cached": false
+    }
+    ```
+
 ## ディレクトリ構成
 
 ```txt
@@ -98,12 +119,15 @@ Backend/
     │   ├── __init__.py
     │   └── endpoints/
     │       ├── analysis.py
+    │       ├── dictionary.py
     │       └── hoge.py
     ├── services/
+    │   ├── dictionary.py
     │   ├── text_analysis.py
     │   └── hoge.py
     └── schemas/
         ├── analysis.py
+        ├── dictionary.py
         └── hoge.py
 ```
 

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -67,6 +67,30 @@ make up-backend
       "deduplicate": false
     }
     ```
+
+- `POST /analysis/vectorize/sentence`
+  - テキスト全体を1つの文章ベクトルに変換して返す
+  - ベクトル取得優先順: `spacy_doc` → `spacy_token_avg` → `content_token_avg` → `hash`
+  - リクエスト例:
+    ```json
+    {
+      "text": "本日の議事録を作成します。API設計と実装方針を共有します。",
+      "normalize": true
+    }
+    ```
+  - レスポンス例（抜粋）:
+    ```json
+    {
+      "text": "本日の議事録を作成します。API設計と実装方針を共有します。",
+      "meta": {
+        "model": "ginza",
+        "vector_dim": 300,
+        "vector_source": "spacy_doc",
+        "normalize": true
+      },
+      "sentence_vector": [0.0312, -0.0124, 0.2011, -0.0942]
+    }
+    ```
   - レスポンス例（抜粋）:
     ```json
     {

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -90,14 +90,22 @@ make up-backend
 - `POST /dictionary/lookup`
   - 用語の意味を日本語で1〜2文の概要として返す
   - 現在は単語DB未実装のため、常にGeminiで生成する
-  - リクエスト例:
+  - `terms` 指定時は、単語ごとに Gemini を非同期並列で呼び出す
+  - リクエスト例（単体）:
     ```json
     {
       "term": "RAG",
       "context": "LLMの会話で出てきた用語"
     }
     ```
-  - レスポンス例:
+  - リクエスト例（複数）:
+    ```json
+    {
+      "terms": ["RAG", "MCP"],
+      "context": "技術会話で出た用語"
+    }
+    ```
+  - レスポンス例（単体）:
     ```json
     {
       "term": "RAG",
@@ -105,6 +113,27 @@ make up-backend
       "source": "gemini",
       "model": "gemini-1.5-flash",
       "cached": false
+    }
+    ```
+  - レスポンス例（複数）:
+    ```json
+    {
+      "results": [
+        {
+          "term": "RAG",
+          "summary": "RAGは、回答生成時に外部知識を検索して根拠を補う手法です。",
+          "source": "gemini",
+          "model": "gemini-1.5-flash",
+          "cached": false
+        },
+        {
+          "term": "MCP",
+          "summary": "MCPは、AIが外部ツールやデータに接続するための標準プロトコルです。",
+          "source": "gemini",
+          "model": "gemini-1.5-flash",
+          "cached": false
+        }
+      ]
     }
     ```
 

--- a/Backend/app/api/__init__.py
+++ b/Backend/app/api/__init__.py
@@ -1,9 +1,10 @@
 import fastapi
-from app.api.endpoints import analysis, hoge
+from app.api.endpoints import analysis, dictionary, hoge
 
 router = fastapi.APIRouter()
 
 router.include_router(analysis.router, prefix="/analysis", tags=["analysis"])
+router.include_router(dictionary.router, prefix="/dictionary", tags=["dictionary"])
 router.include_router(hoge.router, prefix="/hoge", tags=["hoge"])
 
 # 新しくエンドポイントを追加するときは、

--- a/Backend/app/api/endpoints/analysis.py
+++ b/Backend/app/api/endpoints/analysis.py
@@ -1,7 +1,12 @@
 import fastapi
 
-from app.schemas.analysis import VectorizeRequest, VectorizeResponse
-from app.services.text_analysis import vectorize_content_tokens
+from app.schemas.analysis import (
+    SentenceVectorizeRequest,
+    SentenceVectorizeResponse,
+    VectorizeRequest,
+    VectorizeResponse,
+)
+from app.services.text_analysis import vectorize_content_tokens, vectorize_sentence
 
 router = fastapi.APIRouter()
 
@@ -52,3 +57,35 @@ def vectorize(
         deduplicate=body.deduplicate,
     )
     return VectorizeResponse(**result)
+
+
+@router.post(
+    "/vectorize/sentence",
+    response_model=SentenceVectorizeResponse,
+    summary="文章全体を1つのベクトルに変換する",
+    description=(
+        "入力テキストを文章単位でベクトル化します。"
+        " 取得優先順は spacy doc -> spacy token平均 -> 内容語平均 -> hash です。"
+    ),
+    response_description="文章ベクトル化結果（meta と sentence_vector）",
+    responses={
+        200: {"description": "解析成功"},
+        422: {"description": "入力バリデーションエラー（text が空など）"},
+    },
+)
+def vectorize_sentence_endpoint(
+    body: SentenceVectorizeRequest = fastapi.Body(
+        ...,
+        examples={
+            "default": {
+                "summary": "文章ベクトル（正規化あり）",
+                "value": {
+                    "text": "本日の議事録を作成します。API設計と実装方針を共有します。",
+                    "normalize": True,
+                },
+            }
+        },
+    )
+) -> SentenceVectorizeResponse:
+    result = vectorize_sentence(text=body.text, normalize=body.normalize)
+    return SentenceVectorizeResponse(**result)

--- a/Backend/app/api/endpoints/dictionary.py
+++ b/Backend/app/api/endpoints/dictionary.py
@@ -2,20 +2,34 @@ from __future__ import annotations
 
 import fastapi
 
-from app.schemas.dictionary import DictionaryLookupRequest, DictionaryLookupResponse
-from app.services.dictionary import lookup_term_summary
+from app.schemas.dictionary import (
+    DictionaryLookupBatchResponse,
+    DictionaryLookupRequest,
+    DictionaryLookupResponse,
+)
+from app.services.dictionary import lookup_term_summary, lookup_terms_summaries
 
 router = fastapi.APIRouter()
 
 
 @router.post(
     "/lookup",
-    response_model=DictionaryLookupResponse,
+    response_model=DictionaryLookupResponse | DictionaryLookupBatchResponse,
     summary="用語の意味概要を取得する",
-    description="現時点ではGeminiを利用して、入力用語の日本語概要（1〜2文）を返します。",
+    description=(
+        "現時点ではGeminiを利用して、入力用語の日本語概要（1〜2文）を返します。"
+        " term で単体、terms で複数同時検索に対応します。"
+        " 複数時は単語ごとに非同期並列で問い合わせます。"
+    ),
 )
 def lookup(
     body: DictionaryLookupRequest,
-) -> DictionaryLookupResponse:
-    result = lookup_term_summary(term=body.term, context=body.context)
+) -> DictionaryLookupResponse | DictionaryLookupBatchResponse:
+    if body.terms is not None:
+        results = lookup_terms_summaries(terms=body.terms, context=body.context)
+        return DictionaryLookupBatchResponse(
+            results=[DictionaryLookupResponse(**result) for result in results]
+        )
+
+    result = lookup_term_summary(term=body.term or "", context=body.context)
     return DictionaryLookupResponse(**result)

--- a/Backend/app/api/endpoints/dictionary.py
+++ b/Backend/app/api/endpoints/dictionary.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import fastapi
+
+from app.schemas.dictionary import DictionaryLookupRequest, DictionaryLookupResponse
+from app.services.dictionary import lookup_term_summary
+
+router = fastapi.APIRouter()
+
+
+@router.post(
+    "/lookup",
+    response_model=DictionaryLookupResponse,
+    summary="用語の意味概要を取得する",
+    description="現時点ではGeminiを利用して、入力用語の日本語概要（1〜2文）を返します。",
+)
+def lookup(
+    body: DictionaryLookupRequest,
+) -> DictionaryLookupResponse:
+    result = lookup_term_summary(term=body.term, context=body.context)
+    return DictionaryLookupResponse(**result)

--- a/Backend/app/api/endpoints/dictionary.py
+++ b/Backend/app/api/endpoints/dictionary.py
@@ -12,6 +12,8 @@ from app.services.dictionary import lookup_term_summary, lookup_terms_summaries
 router = fastapi.APIRouter()
 
 
+# 辞書検索API本体。
+# term(単体)とterms(複数)のどちらでも受け付ける。
 @router.post(
     "/lookup",
     response_model=DictionaryLookupResponse | DictionaryLookupBatchResponse,
@@ -25,11 +27,13 @@ router = fastapi.APIRouter()
 def lookup(
     body: DictionaryLookupRequest,
 ) -> DictionaryLookupResponse | DictionaryLookupBatchResponse:
+    # 複数検索時はサービス層で並列処理し、results配列で返す。
     if body.terms is not None:
         results = lookup_terms_summaries(terms=body.terms, context=body.context)
         return DictionaryLookupBatchResponse(
             results=[DictionaryLookupResponse(**result) for result in results]
         )
 
+    # 単体検索時は従来フォーマットのレスポンスを返す。
     result = lookup_term_summary(term=body.term or "", context=body.context)
     return DictionaryLookupResponse(**result)

--- a/Backend/app/schemas/analysis.py
+++ b/Backend/app/schemas/analysis.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class VectorizeRequest(BaseModel):
@@ -134,6 +134,13 @@ class SentenceVectorizeRequest(BaseModel):
             ]
         }
     }
+
+    @field_validator("text")
+    @classmethod
+    def validate_text_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("text must not be blank")
+        return value
 
 
 class SentenceVectorizeMeta(BaseModel):

--- a/Backend/app/schemas/analysis.py
+++ b/Backend/app/schemas/analysis.py
@@ -113,3 +113,64 @@ class VectorizeResponse(BaseModel):
             ]
         }
     }
+
+
+class SentenceVectorizeRequest(BaseModel):
+    text: str = Field(
+        min_length=1,
+        description="文章ベクトル化対象テキスト",
+        examples=["本日の議事録を作成します。API設計と実装方針を共有します。"],
+    )
+    normalize: bool = Field(
+        default=True,
+        description="L2正規化したベクトルを返すか",
+        examples=[True],
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"text": "本日の議事録を作成します。API設計と実装方針を共有します。", "normalize": True}
+            ]
+        }
+    }
+
+
+class SentenceVectorizeMeta(BaseModel):
+    model: str = Field(description="利用した埋め込みモデル名", examples=["ginza"])
+    vector_dim: int = Field(description="文章ベクトル次元", examples=[300])
+    vector_source: str = Field(
+        description="文章ベクトルの取得元（spacy_doc / spacy_token_avg / content_token_avg / hash）",
+        examples=["spacy_doc"],
+    )
+    normalize: bool = Field(description="正規化を適用したか", examples=[True])
+    input_token_count: int = Field(description="形態素解析後のトークン数", examples=[15])
+    content_token_count: int = Field(description="内容語として採用されたトークン数", examples=[7])
+
+
+class SentenceVectorizeResponse(BaseModel):
+    text: str = Field(description="入力テキスト（そのまま返却）")
+    meta: SentenceVectorizeMeta = Field(description="文章ベクトル化メタ情報")
+    sentence_vector: list[float] = Field(
+        description="文章ベクトル（vector_dim 個）",
+        examples=[[0.0312, -0.0124, 0.2011, -0.0942]],
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "text": "本日の議事録を作成します。API設計と実装方針を共有します。",
+                    "meta": {
+                        "model": "ginza",
+                        "vector_dim": 300,
+                        "vector_source": "spacy_doc",
+                        "normalize": True,
+                        "input_token_count": 13,
+                        "content_token_count": 6,
+                    },
+                    "sentence_vector": [0.0312, -0.0124, 0.2011, -0.0942],
+                }
+            ]
+        }
+    }

--- a/Backend/app/schemas/dictionary.py
+++ b/Backend/app/schemas/dictionary.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, model_validator
 
 
 class DictionaryLookupRequest(BaseModel):
-    term: str = Field(
-        min_length=1,
-        max_length=128,
-        description="検索したい用語",
+    term: str | None = Field(
+        default=None,
+        description="検索したい用語（単体検索時に指定）",
         examples=["RAG"],
+    )
+    terms: list[str] | None = Field(
+        default=None,
+        max_length=20,
+        description="検索したい用語の配列（複数検索時に指定）",
+        examples=[["RAG", "MCP"]],
     )
     context: str | None = Field(
         default=None,
@@ -17,20 +22,35 @@ class DictionaryLookupRequest(BaseModel):
         examples=["LLMの会話で出てきた用語"],
     )
 
-    @field_validator("term", mode="before")
-    @classmethod
-    def normalize_term(cls, value: object) -> object:
-        if isinstance(value, str):
-            return value.strip()
-        return value
+    @model_validator(mode="after")
+    def normalize_and_validate(self) -> "DictionaryLookupRequest":
+        normalized_term = self.term.strip() if isinstance(self.term, str) else None
+        normalized_terms: list[str] | None = None
+        if self.terms is not None:
+            normalized_terms = [term.strip() if isinstance(term, str) else term for term in self.terms]
 
-    @field_validator("context", mode="before")
-    @classmethod
-    def normalize_context(cls, value: object) -> object:
-        if isinstance(value, str):
-            stripped = value.strip()
-            return stripped or None
-        return value
+        normalized_context = self.context.strip() if isinstance(self.context, str) else self.context
+
+        has_single = bool(normalized_term)
+        has_multi = bool(normalized_terms)
+        if has_single and has_multi:
+            raise ValueError("Specify either term or terms, not both")
+        if not has_single and not has_multi:
+            raise ValueError("Either term or terms is required")
+
+        if normalized_term is not None and len(normalized_term) > 128:
+            raise ValueError("term must be at most 128 characters")
+        if normalized_terms is not None:
+            for term in normalized_terms:
+                if not isinstance(term, str) or not term:
+                    raise ValueError("terms must not include empty strings")
+                if len(term) > 128:
+                    raise ValueError("each term in terms must be at most 128 characters")
+
+        self.term = normalized_term
+        self.terms = normalized_terms
+        self.context = normalized_context or None
+        return self
 
 
 class DictionaryLookupResponse(BaseModel):
@@ -42,3 +62,10 @@ class DictionaryLookupResponse(BaseModel):
     source: str = Field(description='回答ソース（固定: "gemini"）', examples=["gemini"])
     model: str = Field(description="使用したGeminiモデル名", examples=["gemini-1.5-flash"])
     cached: bool = Field(description="キャッシュ利用有無（現時点は常にfalse）", examples=[False])
+
+
+class DictionaryLookupBatchResponse(BaseModel):
+    results: list[DictionaryLookupResponse] = Field(
+        default_factory=list,
+        description="複数用語の検索結果",
+    )

--- a/Backend/app/schemas/dictionary.py
+++ b/Backend/app/schemas/dictionary.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class DictionaryLookupRequest(BaseModel):
+    term: str = Field(
+        min_length=1,
+        max_length=128,
+        description="検索したい用語",
+        examples=["RAG"],
+    )
+    context: str | None = Field(
+        default=None,
+        max_length=1000,
+        description="会話文脈や補足情報。空文字は未指定として扱う",
+        examples=["LLMの会話で出てきた用語"],
+    )
+
+    @field_validator("term", mode="before")
+    @classmethod
+    def normalize_term(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("context", mode="before")
+    @classmethod
+    def normalize_context(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+
+class DictionaryLookupResponse(BaseModel):
+    term: str = Field(description="正規化後の検索語", examples=["RAG"])
+    summary: str = Field(
+        description="用語の日本語概要（1〜2文）",
+        examples=["RAGは、回答時に外部情報を検索して根拠を補う手法です。"],
+    )
+    source: str = Field(description='回答ソース（固定: "gemini"）', examples=["gemini"])
+    model: str = Field(description="使用したGeminiモデル名", examples=["gemini-1.5-flash"])
+    cached: bool = Field(description="キャッシュ利用有無（現時点は常にfalse）", examples=[False])

--- a/Backend/app/schemas/dictionary.py
+++ b/Backend/app/schemas/dictionary.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pydantic import BaseModel, Field, model_validator
 
 
+# 辞書検索リクエスト。
+# term(単体)かterms(複数)のどちらか一方を受け付ける。
 class DictionaryLookupRequest(BaseModel):
     term: str | None = Field(
         default=None,
@@ -24,6 +26,7 @@ class DictionaryLookupRequest(BaseModel):
 
     @model_validator(mode="after")
     def normalize_and_validate(self) -> "DictionaryLookupRequest":
+        # 受け取った文字列を正規化する（前後空白を除去）。
         normalized_term = self.term.strip() if isinstance(self.term, str) else None
         normalized_terms: list[str] | None = None
         if self.terms is not None:
@@ -31,6 +34,7 @@ class DictionaryLookupRequest(BaseModel):
 
         normalized_context = self.context.strip() if isinstance(self.context, str) else self.context
 
+        # term/terms の指定ルールを検証する。
         has_single = bool(normalized_term)
         has_multi = bool(normalized_terms)
         if has_single and has_multi:
@@ -38,6 +42,7 @@ class DictionaryLookupRequest(BaseModel):
         if not has_single and not has_multi:
             raise ValueError("Either term or terms is required")
 
+        # 文字数・空文字の制約を検証する。
         if normalized_term is not None and len(normalized_term) > 128:
             raise ValueError("term must be at most 128 characters")
         if normalized_terms is not None:
@@ -47,12 +52,14 @@ class DictionaryLookupRequest(BaseModel):
                 if len(term) > 128:
                     raise ValueError("each term in terms must be at most 128 characters")
 
+        # 正規化済みの値をモデルに反映する。
         self.term = normalized_term
         self.terms = normalized_terms
         self.context = normalized_context or None
         return self
 
 
+# 単語1件分の辞書検索レスポンス。
 class DictionaryLookupResponse(BaseModel):
     term: str = Field(description="正規化後の検索語", examples=["RAG"])
     summary: str = Field(
@@ -64,6 +71,7 @@ class DictionaryLookupResponse(BaseModel):
     cached: bool = Field(description="キャッシュ利用有無（現時点は常にfalse）", examples=[False])
 
 
+# 複数単語検索時のレスポンス。
 class DictionaryLookupBatchResponse(BaseModel):
     results: list[DictionaryLookupResponse] = Field(
         default_factory=list,

--- a/Backend/app/schemas/dictionary.py
+++ b/Backend/app/schemas/dictionary.py
@@ -31,6 +31,8 @@ class DictionaryLookupRequest(BaseModel):
         normalized_terms: list[str] | None = None
         if self.terms is not None:
             normalized_terms = [term.strip() if isinstance(term, str) else term for term in self.terms]
+            if len(normalized_terms) == 0:
+                normalized_terms = None
 
         normalized_context = self.context.strip() if isinstance(self.context, str) else self.context
 

--- a/Backend/app/services/dictionary.py
+++ b/Backend/app/services/dictionary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any
 
@@ -10,6 +11,7 @@ GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta"
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-1.5-flash")
 GEMINI_TIMEOUT_SECONDS = float(os.getenv("GEMINI_TIMEOUT_SECONDS", "10"))
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+GEMINI_PARALLELISM = int(os.getenv("GEMINI_PARALLELISM", "5"))
 
 
 def lookup_term_summary(term: str, context: str | None = None) -> dict[str, Any]:
@@ -21,13 +23,15 @@ def lookup_term_summary(term: str, context: str | None = None) -> dict[str, Any]
 
     prompt = _build_prompt(normalized_term, context)
     summary, model_name = _call_gemini(prompt)
-    return {
-        "term": normalized_term,
-        "summary": summary,
-        "source": "gemini",
-        "model": model_name,
-        "cached": False,
-    }
+    return _build_lookup_result(normalized_term, summary, model_name)
+
+
+def lookup_terms_summaries(terms: list[str], context: str | None = None) -> list[dict[str, Any]]:
+    normalized_terms = [term.strip() for term in terms]
+    if not normalized_terms:
+        return []
+
+    return asyncio.run(_lookup_terms_individually_async(normalized_terms, context))
 
 
 def _lookup_term_from_db(term: str) -> dict[str, Any] | None:
@@ -44,6 +48,51 @@ def _build_prompt(term: str, context: str | None) -> str:
         f"用語: {term}\n"
         f"文脈: {normalized_context}"
     )
+
+
+def _build_lookup_result(term: str, summary: str, model_name: str) -> dict[str, Any]:
+    return {
+        "term": term,
+        "summary": summary,
+        "source": "gemini",
+        "model": model_name,
+        "cached": False,
+    }
+
+
+async def _lookup_terms_individually_async(
+    terms: list[str],
+    context: str | None,
+) -> list[dict[str, Any]]:
+    unique_terms = list(dict.fromkeys(terms))
+    if not unique_terms:
+        return []
+
+    semaphore = asyncio.Semaphore(max(1, GEMINI_PARALLELISM))
+    async with httpx.AsyncClient() as client:
+        async def _worker(term: str) -> dict[str, Any]:
+            async with semaphore:
+                return await _lookup_term_summary_async(term=term, context=context, client=client)
+
+        unique_results = await asyncio.gather(*(_worker(term) for term in unique_terms))
+
+    by_term = {item["term"]: item for item in unique_results}
+    return [by_term[term].copy() for term in terms]
+
+
+async def _lookup_term_summary_async(
+    term: str,
+    context: str | None,
+    client: httpx.AsyncClient,
+) -> dict[str, Any]:
+    normalized_term = term.strip()
+    db_result = _lookup_term_from_db(normalized_term)
+    if db_result is not None:
+        return db_result
+
+    prompt = _build_prompt(normalized_term, context)
+    summary, model_name = await _call_gemini_async(prompt, client=client)
+    return _build_lookup_result(normalized_term, summary, model_name)
 
 
 def _call_gemini(prompt: str) -> tuple[str, str]:
@@ -84,6 +133,54 @@ def _call_gemini(prompt: str) -> tuple[str, str]:
             detail="Gemini upstream returned invalid response",
         ) from exc
 
+    return _extract_summary_text(payload_json), GEMINI_MODEL
+
+
+async def _call_gemini_async(
+    prompt: str,
+    client: httpx.AsyncClient,
+) -> tuple[str, str]:
+    if not GEMINI_API_KEY:
+        raise fastapi.HTTPException(status_code=503, detail="GEMINI_API_KEY is not configured")
+
+    url = f"{GEMINI_API_BASE}/models/{GEMINI_MODEL}:generateContent?key={GEMINI_API_KEY}"
+    payload = {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": prompt}],
+            }
+        ],
+        "generationConfig": {
+            "temperature": 0.2,
+            "maxOutputTokens": 120,
+            "topP": 0.9,
+        },
+    }
+
+    try:
+        response = await client.post(
+            url,
+            headers={"Content-Type": "application/json"},
+            json=payload,
+            timeout=GEMINI_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload_json = response.json()
+    except httpx.TimeoutException as exc:
+        raise fastapi.HTTPException(status_code=504, detail="Gemini API request timed out") from exc
+    except httpx.HTTPError as exc:
+        raise fastapi.HTTPException(status_code=502, detail="Failed to call Gemini API") from exc
+    except ValueError as exc:
+        raise fastapi.HTTPException(
+            status_code=502,
+            detail="Gemini upstream returned invalid response",
+        ) from exc
+
+    return _extract_summary_text(payload_json), GEMINI_MODEL
+
+
+def _extract_summary_text(payload_json: dict[str, Any]) -> str:
     try:
         candidates = payload_json["candidates"]
         candidate = candidates[0]
@@ -102,7 +199,7 @@ def _call_gemini(prompt: str) -> tuple[str, str]:
             continue
         normalized_text = text.replace("\n", " ").strip()
         if normalized_text:
-            return normalized_text, GEMINI_MODEL
+            return normalized_text
 
     raise fastapi.HTTPException(
         status_code=502,

--- a/Backend/app/services/dictionary.py
+++ b/Backend/app/services/dictionary.py
@@ -14,19 +14,27 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 GEMINI_PARALLELISM = int(os.getenv("GEMINI_PARALLELISM", "5"))
 
 
+# 単語1件の概要を取得する。
+# 先にDBを参照し、未ヒット時のみGeminiへフォールバックする。
 def lookup_term_summary(term: str, context: str | None = None) -> dict[str, Any]:
+    # 入力揺れを減らすため前後空白を除去する。
     normalized_term = term.strip()
 
+    # 将来の辞書DB接続を想定した優先参照ポイント。
     db_result = _lookup_term_from_db(normalized_term)
     if db_result is not None:
         return db_result
 
+    # DB未ヒット時はプロンプトを作ってGeminiを呼ぶ。
     prompt = _build_prompt(normalized_term, context)
     summary, model_name = _call_gemini(prompt)
     return _build_lookup_result(normalized_term, summary, model_name)
 
 
+# 複数単語の概要をまとめて取得する。
+# 同期APIから呼びやすいよう、内部の非同期処理をここで実行する。
 def lookup_terms_summaries(terms: list[str], context: str | None = None) -> list[dict[str, Any]]:
+    # 各単語の正規化（空白除去）。
     normalized_terms = [term.strip() for term in terms]
     if not normalized_terms:
         return []
@@ -34,11 +42,14 @@ def lookup_terms_summaries(terms: list[str], context: str | None = None) -> list
     return asyncio.run(_lookup_terms_individually_async(normalized_terms, context))
 
 
+# DB問い合わせの差し込みポイント。
+# 現状は未実装のため常にNoneを返す。
 def _lookup_term_from_db(term: str) -> dict[str, Any] | None:
     _ = term
     return None
 
 
+# Geminiへ渡す単語説明用プロンプトを組み立てる。
 def _build_prompt(term: str, context: str | None) -> str:
     normalized_context = (context or "").strip() or "なし"
     return (
@@ -50,6 +61,7 @@ def _build_prompt(term: str, context: str | None) -> str:
     )
 
 
+# APIレスポンス用の共通フォーマットを作る。
 def _build_lookup_result(term: str, summary: str, model_name: str) -> dict[str, Any]:
     return {
         "term": term,
@@ -60,26 +72,33 @@ def _build_lookup_result(term: str, summary: str, model_name: str) -> dict[str, 
     }
 
 
+# 複数単語を非同期並列で問い合わせる。
+# 重複単語は1回だけ呼び出し、返却時に元の入力順へ復元する。
 async def _lookup_terms_individually_async(
     terms: list[str],
     context: str | None,
 ) -> list[dict[str, Any]]:
+    # API呼び出し回数を抑えるため重複を除去する。
     unique_terms = list(dict.fromkeys(terms))
     if not unique_terms:
         return []
 
+    # 上流への過負荷を避けるため同時実行数を制限する。
     semaphore = asyncio.Semaphore(max(1, GEMINI_PARALLELISM))
     async with httpx.AsyncClient() as client:
         async def _worker(term: str) -> dict[str, Any]:
             async with semaphore:
                 return await _lookup_term_summary_async(term=term, context=context, client=client)
 
+        # 各単語の問い合わせを同時に実行する。
         unique_results = await asyncio.gather(*(_worker(term) for term in unique_terms))
 
+    # 入力順を保つため、ユニーク結果から並べ直して返す。
     by_term = {item["term"]: item for item in unique_results}
     return [by_term[term].copy() for term in terms]
 
 
+# 非同期経路で単語1件の概要を取得する。
 async def _lookup_term_summary_async(
     term: str,
     context: str | None,
@@ -95,10 +114,13 @@ async def _lookup_term_summary_async(
     return _build_lookup_result(normalized_term, summary, model_name)
 
 
+# Gemini REST APIを同期で呼び出し、要約文とモデル名を返す。
 def _call_gemini(prompt: str) -> tuple[str, str]:
+    # 設定不足は上流呼び出し前に明示的に失敗させる。
     if not GEMINI_API_KEY:
         raise fastapi.HTTPException(status_code=503, detail="GEMINI_API_KEY is not configured")
 
+    # Gemini generateContent のリクエストを組み立てる。
     url = f"{GEMINI_API_BASE}/models/{GEMINI_MODEL}:generateContent?key={GEMINI_API_KEY}"
     payload = {
         "contents": [
@@ -114,6 +136,7 @@ def _call_gemini(prompt: str) -> tuple[str, str]:
         },
     }
 
+    # ネットワーク/上流エラーをAPI仕様のHTTPステータスへ変換する。
     try:
         response = httpx.post(
             url,
@@ -136,13 +159,16 @@ def _call_gemini(prompt: str) -> tuple[str, str]:
     return _extract_summary_text(payload_json), GEMINI_MODEL
 
 
+# Gemini REST APIを非同期で呼び出し、要約文とモデル名を返す。
 async def _call_gemini_async(
     prompt: str,
     client: httpx.AsyncClient,
 ) -> tuple[str, str]:
+    # 設定不足は上流呼び出し前に明示的に失敗させる。
     if not GEMINI_API_KEY:
         raise fastapi.HTTPException(status_code=503, detail="GEMINI_API_KEY is not configured")
 
+    # Gemini generateContent のリクエストを組み立てる。
     url = f"{GEMINI_API_BASE}/models/{GEMINI_MODEL}:generateContent?key={GEMINI_API_KEY}"
     payload = {
         "contents": [
@@ -158,6 +184,7 @@ async def _call_gemini_async(
         },
     }
 
+    # ネットワーク/上流エラーをAPI仕様のHTTPステータスへ変換する。
     try:
         response = await client.post(
             url,
@@ -180,6 +207,8 @@ async def _call_gemini_async(
     return _extract_summary_text(payload_json), GEMINI_MODEL
 
 
+# Gemini応答から本文テキストを抽出し、空行・改行を正規化する。
+# 想定スキーマを満たさない場合は不正応答として502に変換する。
 def _extract_summary_text(payload_json: dict[str, Any]) -> str:
     try:
         candidates = payload_json["candidates"]
@@ -191,6 +220,7 @@ def _extract_summary_text(payload_json: dict[str, Any]) -> str:
             detail="Gemini upstream returned invalid response",
         ) from exc
 
+    # parts配列の先頭から、最初の非空テキストを採用する。
     for part in parts:
         if not isinstance(part, dict):
             continue

--- a/Backend/app/services/dictionary.py
+++ b/Backend/app/services/dictionary.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import fastapi
+import httpx
+
+GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-1.5-flash")
+GEMINI_TIMEOUT_SECONDS = float(os.getenv("GEMINI_TIMEOUT_SECONDS", "10"))
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+
+def lookup_term_summary(term: str, context: str | None = None) -> dict[str, Any]:
+    normalized_term = term.strip()
+
+    db_result = _lookup_term_from_db(normalized_term)
+    if db_result is not None:
+        return db_result
+
+    prompt = _build_prompt(normalized_term, context)
+    summary, model_name = _call_gemini(prompt)
+    return {
+        "term": normalized_term,
+        "summary": summary,
+        "source": "gemini",
+        "model": model_name,
+        "cached": False,
+    }
+
+
+def _lookup_term_from_db(term: str) -> dict[str, Any] | None:
+    _ = term
+    return None
+
+
+def _build_prompt(term: str, context: str | None) -> str:
+    normalized_context = (context or "").strip() or "なし"
+    return (
+        "あなたは辞書アシスタントです。\n"
+        "次の用語を、会話中にすぐ理解できるように日本語で1〜2文で説明してください。\n"
+        "専門用語の言い換えを優先し、簡潔に答えてください。\n"
+        f"用語: {term}\n"
+        f"文脈: {normalized_context}"
+    )
+
+
+def _call_gemini(prompt: str) -> tuple[str, str]:
+    if not GEMINI_API_KEY:
+        raise fastapi.HTTPException(status_code=503, detail="GEMINI_API_KEY is not configured")
+
+    url = f"{GEMINI_API_BASE}/models/{GEMINI_MODEL}:generateContent?key={GEMINI_API_KEY}"
+    payload = {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": prompt}],
+            }
+        ],
+        "generationConfig": {
+            "temperature": 0.2,
+            "maxOutputTokens": 120,
+            "topP": 0.9,
+        },
+    }
+
+    try:
+        response = httpx.post(
+            url,
+            headers={"Content-Type": "application/json"},
+            json=payload,
+            timeout=GEMINI_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload_json = response.json()
+    except httpx.TimeoutException as exc:
+        raise fastapi.HTTPException(status_code=504, detail="Gemini API request timed out") from exc
+    except httpx.HTTPError as exc:
+        raise fastapi.HTTPException(status_code=502, detail="Failed to call Gemini API") from exc
+    except ValueError as exc:
+        raise fastapi.HTTPException(
+            status_code=502,
+            detail="Gemini upstream returned invalid response",
+        ) from exc
+
+    try:
+        candidates = payload_json["candidates"]
+        candidate = candidates[0]
+        parts = candidate["content"]["parts"]
+    except (TypeError, KeyError, IndexError) as exc:
+        raise fastapi.HTTPException(
+            status_code=502,
+            detail="Gemini upstream returned invalid response",
+        ) from exc
+
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        text = part.get("text")
+        if not isinstance(text, str):
+            continue
+        normalized_text = text.replace("\n", " ").strip()
+        if normalized_text:
+            return normalized_text, GEMINI_MODEL
+
+    raise fastapi.HTTPException(
+        status_code=502,
+        detail="Gemini upstream returned invalid response",
+    )

--- a/Backend/app/services/text_analysis.py
+++ b/Backend/app/services/text_analysis.py
@@ -429,6 +429,15 @@ def _average_vectors(vectors: list[list[float]]) -> list[float]:
     return [v / count for v in totals]
 
 
+def _l2_normalize(vector: list[float]) -> list[float]:
+    if not vector:
+        return []
+    norm = math.sqrt(sum(v * v for v in vector))
+    if norm <= 0.0:
+        return vector
+    return [v / norm for v in vector]
+
+
 # ベクトル次元はモデル語彙 -> token vector -> ハッシュ既定値の順で決定する。
 def _resolve_vector_dim(nlp: Any | None, doc: Any | None) -> int:
     if nlp is not None:
@@ -596,6 +605,89 @@ def vectorize_content_tokens(
             "vector_source_counts": dict(source_map),
         },
         "tokens": results,
+    }
+
+
+def vectorize_sentence(text: str, normalize: bool = True) -> dict[str, Any]:
+    """Vectorize the whole sentence and return one vector."""
+    if not text.strip():
+        return {
+            "text": text,
+            "meta": {
+                "model": "none",
+                "vector_dim": 0,
+                "vector_source": "none",
+                "normalize": normalize,
+                "input_token_count": 0,
+                "content_token_count": 0,
+            },
+            "sentence_vector": [],
+        }
+
+    tokens = morphological_analysis(text)
+    nlp = _get_spacy_ja()
+    doc = nlp(text) if nlp else None
+    vector_source = "hash"
+    sentence_vector: list[float] = []
+    content_token_count = 0
+
+    if doc is not None and doc.has_vector and float(doc.vector_norm) > 0.0:
+        sentence_vector = [float(v) for v in doc.vector]
+        vector_source = "spacy_doc"
+
+    if not sentence_vector and doc is not None:
+        token_vectors = [
+            [float(v) for v in token.vector]
+            for token in doc
+            if (not token.is_space) and token.has_vector and float(token.vector_norm) > 0.0
+        ]
+        if token_vectors:
+            sentence_vector = _average_vectors(token_vectors)
+            vector_source = "spacy_token_avg"
+
+    if not sentence_vector:
+        content = vectorize_content_tokens(text=text, deduplicate=False)
+        content_vectors = [token["vector"] for token in content["tokens"] if token.get("vector")]
+        content_token_count = len(content_vectors)
+        if content_vectors:
+            sentence_vector = _average_vectors(content_vectors)
+            vector_source = "content_token_avg"
+
+    if not sentence_vector:
+        dim = _resolve_vector_dim(nlp, doc)
+        sentence_vector = _build_hashed_vector(text, dim)
+        vector_source = "hash"
+
+    if normalize:
+        sentence_vector = _l2_normalize(sentence_vector)
+
+    vector_dim = len(sentence_vector)
+    model_name = "hash-fallback"
+    if nlp is not None:
+        model_name = str(nlp.meta.get("name", "ja_ginza"))
+
+    if content_token_count == 0:
+        content_token_count = len(
+            [
+                token
+                for token in tokens
+                if _should_vectorize_pos(
+                    token["pos"], _DEFAULT_VECTOR_INCLUDE_POS, _DEFAULT_VECTOR_EXCLUDE_POS
+                )
+            ]
+        )
+
+    return {
+        "text": text,
+        "meta": {
+            "model": model_name,
+            "vector_dim": vector_dim,
+            "vector_source": vector_source,
+            "normalize": normalize,
+            "input_token_count": len(tokens),
+            "content_token_count": content_token_count,
+        },
+        "sentence_vector": [round(float(v), 6) for v in sentence_vector],
     }
 
 

--- a/Backend/app/services/text_analysis.py
+++ b/Backend/app/services/text_analysis.py
@@ -396,7 +396,7 @@ def dependency_parse(text: str) -> list[dict[str, Any]]:
 
 # 外部モデルが使えない場合の最終フォールバック。
 # 語から決定的に同じベクトルを生成する（疑似埋め込み）。
-def _build_hashed_vector(term: str, dim: int) -> list[float]:
+def _build_hashed_vector(term: str, dim: int, *, normalize: bool = True) -> list[float]:
     seed = hashlib.sha256(term.encode("utf-8")).digest()
     values: list[float] = []
     counter = 0
@@ -409,6 +409,9 @@ def _build_hashed_vector(term: str, dim: int) -> list[float]:
             raw = int.from_bytes(block[i : i + 4], "little", signed=False)
             values.append((raw / 4294967295.0) * 2.0 - 1.0)
         counter += 1
+
+    if not normalize:
+        return values
 
     norm = math.sqrt(sum(v * v for v in values))
     if norm <= 0.0:
@@ -655,7 +658,8 @@ def vectorize_sentence(text: str, normalize: bool = True) -> dict[str, Any]:
 
     if not sentence_vector:
         dim = _resolve_vector_dim(nlp, doc)
-        sentence_vector = _build_hashed_vector(text, dim)
+        # normalize=False のときは生ベクトルを返すため、ここでは未正規化で生成する。
+        sentence_vector = _build_hashed_vector(text, dim, normalize=False)
         vector_source = "hash"
 
     if normalize:

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -1,5 +1,11 @@
 import fastapi
 from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+from pathlib import Path
+
+# Backend/.env を起動時に読み込む（既存の環境変数は上書きしない）。
+load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
+
 from app.api import router
 
 app = fastapi.FastAPI(
@@ -12,6 +18,7 @@ app = fastapi.FastAPI(
     ),
     openapi_tags=[
         {"name": "analysis", "description": "テキスト解析・ベクトル化API"},
+        {"name": "dictionary", "description": "単語の意味概要検索API"},
         {"name": "hoge", "description": "サンプルAPI"},
     ],
 )

--- a/Backend/pyproject.toml
+++ b/Backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "uvicorn>=0.30.0",
     "pydantic>=2.7.0",
     "python-dotenv>=1.0.0",
+    "httpx>=0.27.0",
     "sudachipy>=0.6.10",
     "sudachidict-core>=20240109",
     "spacy>=3.7.0",
@@ -18,6 +19,5 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "httpx>=0.27.0",
     "pytest>=8.2.0",
 ]

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn
 pydantic
 python-dotenv
+httpx
 sudachipy
 sudachidict-core
 spacy

--- a/Backend/tests/test_analysis_endpoint.py
+++ b/Backend/tests/test_analysis_endpoint.py
@@ -60,3 +60,8 @@ def test_vectorize_sentence_endpoint_returns_vector() -> None:
 def test_vectorize_sentence_endpoint_validates_empty_text() -> None:
     res = client.post("/analysis/vectorize/sentence", json={"text": ""})
     assert res.status_code == 422
+
+
+def test_vectorize_sentence_endpoint_validates_whitespace_only_text() -> None:
+    res = client.post("/analysis/vectorize/sentence", json={"text": "   "})
+    assert res.status_code == 422

--- a/Backend/tests/test_analysis_endpoint.py
+++ b/Backend/tests/test_analysis_endpoint.py
@@ -33,3 +33,30 @@ def test_vectorize_endpoint_returns_vectors() -> None:
 def test_vectorize_endpoint_validates_empty_text() -> None:
     res = client.post("/analysis/vectorize", json={"text": ""})
     assert res.status_code == 422
+
+
+def test_vectorize_sentence_endpoint_returns_vector() -> None:
+    res = client.post(
+        "/analysis/vectorize/sentence",
+        json={
+            "text": "本日の議事録を作成します。API設計と実装方針を共有します。",
+            "normalize": True,
+        },
+    )
+    assert res.status_code == 200
+    body = res.json()
+
+    assert "meta" in body
+    assert body["meta"]["vector_dim"] > 0
+    assert len(body["sentence_vector"]) == body["meta"]["vector_dim"]
+    assert body["meta"]["vector_source"] in {
+        "spacy_doc",
+        "spacy_token_avg",
+        "content_token_avg",
+        "hash",
+    }
+
+
+def test_vectorize_sentence_endpoint_validates_empty_text() -> None:
+    res = client.post("/analysis/vectorize/sentence", json={"text": ""})
+    assert res.status_code == 422

--- a/Backend/tests/test_dictionary_endpoint.py
+++ b/Backend/tests/test_dictionary_endpoint.py
@@ -63,6 +63,30 @@ def test_dictionary_lookup_batch_returns_200(monkeypatch) -> None:
     assert body["results"][1]["term"] == "MCP"
 
 
+def test_dictionary_lookup_treats_empty_terms_as_single(monkeypatch) -> None:
+    def _mock_lookup(term: str, context: str | None = None):
+        _ = context
+        return {
+            "term": term,
+            "summary": "RAGは回答時に外部情報を参照して根拠を補う手法です。",
+            "source": "gemini",
+            "model": "gemini-1.5-flash",
+            "cached": False,
+        }
+
+    monkeypatch.setattr(dictionary_endpoint, "lookup_term_summary", _mock_lookup)
+
+    res = client.post(
+        "/dictionary/lookup",
+        json={"term": "RAG", "terms": []},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["term"] == "RAG"
+    assert "results" not in body
+
+
 def test_dictionary_lookup_validates_empty_term() -> None:
     res = client.post("/dictionary/lookup", json={"term": ""})
     assert res.status_code == 422

--- a/Backend/tests/test_dictionary_endpoint.py
+++ b/Backend/tests/test_dictionary_endpoint.py
@@ -1,0 +1,50 @@
+import fastapi
+from fastapi.testclient import TestClient
+
+import app.api.endpoints.dictionary as dictionary_endpoint
+from main import app
+
+client = TestClient(app)
+
+
+def test_dictionary_lookup_returns_200(monkeypatch) -> None:
+    def _mock_lookup(term: str, context: str | None = None):
+        _ = context
+        return {
+            "term": term,
+            "summary": "RAGは回答時に外部情報を参照して根拠を補う手法です。",
+            "source": "gemini",
+            "model": "gemini-1.5-flash",
+            "cached": False,
+        }
+
+    monkeypatch.setattr(dictionary_endpoint, "lookup_term_summary", _mock_lookup)
+
+    res = client.post(
+        "/dictionary/lookup",
+        json={"term": "RAG", "context": "LLMの会話で出てきた用語"},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["term"] == "RAG"
+    assert body["source"] == "gemini"
+    assert body["model"] == "gemini-1.5-flash"
+    assert body["cached"] is False
+    assert body["summary"]
+
+
+def test_dictionary_lookup_validates_empty_term() -> None:
+    res = client.post("/dictionary/lookup", json={"term": ""})
+    assert res.status_code == 422
+
+
+def test_dictionary_lookup_propagates_503(monkeypatch) -> None:
+    def _raise_error(*_args, **_kwargs):
+        raise fastapi.HTTPException(status_code=503, detail="GEMINI_API_KEY is not configured")
+
+    monkeypatch.setattr(dictionary_endpoint, "lookup_term_summary", _raise_error)
+    res = client.post("/dictionary/lookup", json={"term": "RAG"})
+
+    assert res.status_code == 503
+    assert res.json()["detail"] == "GEMINI_API_KEY is not configured"

--- a/Backend/tests/test_dictionary_endpoint.py
+++ b/Backend/tests/test_dictionary_endpoint.py
@@ -34,8 +34,42 @@ def test_dictionary_lookup_returns_200(monkeypatch) -> None:
     assert body["summary"]
 
 
+def test_dictionary_lookup_batch_returns_200(monkeypatch) -> None:
+    def _mock_lookup_terms(terms: list[str], context: str | None = None):
+        _ = context
+        return [
+            {
+                "term": term,
+                "summary": f"{term}の説明です。",
+                "source": "gemini",
+                "model": "gemini-1.5-flash",
+                "cached": False,
+            }
+            for term in terms
+        ]
+
+    monkeypatch.setattr(dictionary_endpoint, "lookup_terms_summaries", _mock_lookup_terms)
+
+    res = client.post(
+        "/dictionary/lookup",
+        json={"terms": ["RAG", "MCP"], "context": "技術会話で出た用語"},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert "results" in body
+    assert len(body["results"]) == 2
+    assert body["results"][0]["term"] == "RAG"
+    assert body["results"][1]["term"] == "MCP"
+
+
 def test_dictionary_lookup_validates_empty_term() -> None:
     res = client.post("/dictionary/lookup", json={"term": ""})
+    assert res.status_code == 422
+
+
+def test_dictionary_lookup_validates_term_and_terms_together() -> None:
+    res = client.post("/dictionary/lookup", json={"term": "RAG", "terms": ["MCP"]})
     assert res.status_code == 422
 
 

--- a/Backend/tests/test_dictionary_service.py
+++ b/Backend/tests/test_dictionary_service.py
@@ -1,0 +1,65 @@
+import fastapi
+import pytest
+
+import app.services.dictionary as dictionary_service
+
+
+def test_lookup_term_summary_returns_gemini_result(monkeypatch) -> None:
+    monkeypatch.setattr(dictionary_service, "_lookup_term_from_db", lambda _term: None)
+    monkeypatch.setattr(
+        dictionary_service,
+        "_call_gemini",
+        lambda _prompt: ("RAGは外部情報を参照して回答の根拠を補う手法です。", "gemini-1.5-flash"),
+    )
+
+    result = dictionary_service.lookup_term_summary("  RAG  ", context="LLMの会話で出てきた用語")
+
+    assert result["term"] == "RAG"
+    assert result["summary"] == "RAGは外部情報を参照して回答の根拠を補う手法です。"
+    assert result["source"] == "gemini"
+    assert result["model"] == "gemini-1.5-flash"
+    assert result["cached"] is False
+
+
+def test_call_gemini_raises_503_when_api_key_missing(monkeypatch) -> None:
+    monkeypatch.setattr(dictionary_service, "GEMINI_API_KEY", None)
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        dictionary_service._call_gemini("test prompt")
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "GEMINI_API_KEY is not configured"
+
+
+def test_call_gemini_raises_504_on_timeout(monkeypatch) -> None:
+    monkeypatch.setattr(dictionary_service, "GEMINI_API_KEY", "dummy-key")
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise dictionary_service.httpx.TimeoutException("timed out")
+
+    monkeypatch.setattr(dictionary_service.httpx, "post", _raise_timeout)
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        dictionary_service._call_gemini("test prompt")
+
+    assert exc_info.value.status_code == 504
+    assert exc_info.value.detail == "Gemini API request timed out"
+
+
+def test_call_gemini_raises_502_on_invalid_payload(monkeypatch) -> None:
+    monkeypatch.setattr(dictionary_service, "GEMINI_API_KEY", "dummy-key")
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self):
+            return {"unexpected": "payload"}
+
+    monkeypatch.setattr(dictionary_service.httpx, "post", lambda *_args, **_kwargs: _FakeResponse())
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        dictionary_service._call_gemini("test prompt")
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "Gemini upstream returned invalid response"

--- a/Backend/tests/test_dictionary_service.py
+++ b/Backend/tests/test_dictionary_service.py
@@ -21,6 +21,32 @@ def test_lookup_term_summary_returns_gemini_result(monkeypatch) -> None:
     assert result["cached"] is False
 
 
+def test_lookup_terms_summaries_returns_multiple_results(monkeypatch) -> None:
+    async def _mock_async_lookup(terms: list[str], context: str | None):
+        assert context == "技術会話で出た用語"
+        return [
+            {
+                "term": term,
+                "summary": f"{term}の説明です。",
+                "source": "gemini",
+                "model": "gemini-1.5-flash",
+                "cached": False,
+            }
+            for term in terms
+        ]
+
+    monkeypatch.setattr(dictionary_service, "_lookup_terms_individually_async", _mock_async_lookup)
+
+    results = dictionary_service.lookup_terms_summaries(
+        [" RAG ", "MCP"],
+        context="技術会話で出た用語",
+    )
+
+    assert len(results) == 2
+    assert results[0]["term"] == "RAG"
+    assert results[1]["term"] == "MCP"
+
+
 def test_call_gemini_raises_503_when_api_key_missing(monkeypatch) -> None:
     monkeypatch.setattr(dictionary_service, "GEMINI_API_KEY", None)
 

--- a/Backend/tests/test_text_analysis_service.py
+++ b/Backend/tests/test_text_analysis_service.py
@@ -7,6 +7,7 @@ from app.services.text_analysis import (
     vectorize_content_tokens,
     vectorize_sentence,
 )
+import math
 
 
 def test_morphological_analysis_returns_tokens() -> None:
@@ -140,3 +141,26 @@ def test_vectorize_sentence_empty_text_returns_empty_vector() -> None:
     assert result["sentence_vector"] == []
     assert result["meta"]["vector_dim"] == 0
     assert result["meta"]["vector_source"] == "none"
+
+
+def test_vectorize_sentence_hash_fallback_honors_normalize_flag(monkeypatch) -> None:
+    monkeypatch.setattr(text_analysis, "_get_spacy_ja", lambda: None)
+    monkeypatch.setattr(
+        text_analysis,
+        "vectorize_content_tokens",
+        lambda text, deduplicate=False: {"text": text, "meta": {}, "tokens": []},
+    )
+
+    raw = vectorize_sentence("hash fallback test", normalize=False)
+    normalized = vectorize_sentence("hash fallback test", normalize=True)
+
+    raw_norm = math.sqrt(sum(v * v for v in raw["sentence_vector"]))
+    normalized_norm = math.sqrt(sum(v * v for v in normalized["sentence_vector"]))
+
+    assert raw["meta"]["vector_source"] == "hash"
+    assert normalized["meta"]["vector_source"] == "hash"
+    assert raw["meta"]["normalize"] is False
+    assert normalized["meta"]["normalize"] is True
+    assert raw["sentence_vector"] != normalized["sentence_vector"]
+    assert raw_norm > 1.0
+    assert abs(normalized_norm - 1.0) < 1e-6

--- a/Backend/tests/test_text_analysis_service.py
+++ b/Backend/tests/test_text_analysis_service.py
@@ -5,6 +5,7 @@ from app.services.text_analysis import (
     tfidf_scores,
     top_terms_by_tfidf,
     vectorize_content_tokens,
+    vectorize_sentence,
 )
 
 
@@ -118,3 +119,24 @@ def test_morphological_analysis_fallback_keeps_auxiliary_token(monkeypatch) -> N
 
     pos_by_surface = {token["surface"]: token["pos"] for token in tokens}
     assert pos_by_surface["です"] == "AUX"
+
+
+def test_vectorize_sentence_returns_single_vector() -> None:
+    result = vectorize_sentence("今日は自然言語処理を勉強して、結果を共有します。")
+
+    assert result["meta"]["vector_dim"] > 0
+    assert len(result["sentence_vector"]) == result["meta"]["vector_dim"]
+    assert result["meta"]["vector_source"] in {
+        "spacy_doc",
+        "spacy_token_avg",
+        "content_token_avg",
+        "hash",
+    }
+
+
+def test_vectorize_sentence_empty_text_returns_empty_vector() -> None:
+    result = vectorize_sentence("", normalize=True)
+
+    assert result["sentence_vector"] == []
+    assert result["meta"]["vector_dim"] == 0
+    assert result["meta"]["vector_source"] == "none"

--- a/Backend/uv.lock
+++ b/Backend/uv.lock
@@ -307,7 +307,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -434,6 +434,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "ginza" },
+    { name = "httpx" },
     { name = "ja-ginza" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -445,7 +446,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pytest" },
 ]
 
@@ -453,6 +453,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "ginza", specifier = ">=5.2.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "ja-ginza", specifier = ">=5.2.0" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -463,10 +464,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "pytest", specifier = ">=8.2.0" },
-]
+dev = [{ name = "pytest", specifier = ">=8.2.0" }]
 
 [[package]]
 name = "markdown-it-py"

--- a/doc/frontend-api-vectorize.md
+++ b/doc/frontend-api-vectorize.md
@@ -1,6 +1,6 @@
-# フロント向け API 仕様（`/analysis/vectorize`）
+# フロント向け API 仕様（ベクトル化）
 
-このドキュメントは、Frontend メンバーが `POST /analysis/vectorize` を利用するための実装向け仕様です。  
+このドキュメントは、Frontend メンバーがベクトル化APIを利用するための実装向け仕様です。  
 バックエンド内部の実装詳細は以下を参照してください。
 
 - `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/doc/text-analysis-methods.md`
@@ -14,9 +14,11 @@
 
 ## 2. エンドポイント
 
-- Method: `POST`
-- Path: `/analysis/vectorize`
-- Content-Type: `application/json`
+- `POST /analysis/vectorize`
+  - 単語（内容語）ベクトルを返す
+- `POST /analysis/vectorize/sentence`
+  - 文章全体の単一ベクトルを返す
+- 共通: `Content-Type: application/json`
 
 ## 3. リクエスト
 
@@ -153,5 +155,71 @@ export type VectorizeResponse = {
     vector_source_counts: Record<string, number>;
   };
   tokens: VectorizedToken[];
+};
+```
+
+## 7. 文章ベクトルAPI（`/analysis/vectorize/sentence`）
+
+### 7.1 リクエスト
+
+```json
+{
+  "text": "本日の議事録を作成します。API設計と実装方針を共有します。",
+  "normalize": true
+}
+```
+
+| 項目 | 型 | 必須 | 既定値 | 説明 |
+|---|---|---|---|---|
+| `text` | `string` | 必須 | - | 文章ベクトル化対象テキスト（1文字以上） |
+| `normalize` | `boolean` | 任意 | `true` | 返却ベクトルにL2正規化を適用するか |
+
+### 7.2 レスポンス
+
+```jsonc
+{
+  "text": "本日の議事録を作成します。API設計と実装方針を共有します。",
+  "meta": {
+    "model": "ginza",
+    "vector_dim": 300,
+    "vector_source": "spacy_doc",
+    "normalize": true,
+    "input_token_count": 13,
+    "content_token_count": 6
+  },
+  "sentence_vector": [0.0312, -0.0124, 0.2011, -0.0942, ...]
+}
+```
+
+| 項目 | 型 | 説明 |
+|---|---|---|
+| `text` | `string` | 入力テキスト（そのまま返却） |
+| `meta.model` | `string` | 利用モデル名（例: `ginza`） |
+| `meta.vector_dim` | `number` | 文章ベクトルの次元数 |
+| `meta.vector_source` | `string` | ベクトル取得元（`spacy_doc` / `spacy_token_avg` / `content_token_avg` / `hash`） |
+| `meta.normalize` | `boolean` | 正規化を適用したか |
+| `meta.input_token_count` | `number` | 形態素解析後トークン数 |
+| `meta.content_token_count` | `number` | 内容語として採用されたトークン数 |
+| `sentence_vector` | `number[]` | 文章ベクトル本体（`meta.vector_dim` 個） |
+
+### 7.3 TypeScript 型サンプル
+
+```ts
+export type SentenceVectorizeRequest = {
+  text: string;
+  normalize?: boolean;
+};
+
+export type SentenceVectorizeResponse = {
+  text: string;
+  meta: {
+    model: string;
+    vector_dim: number;
+    vector_source: "spacy_doc" | "spacy_token_avg" | "content_token_avg" | "hash" | string;
+    normalize: boolean;
+    input_token_count: number;
+    content_token_count: number;
+  };
+  sentence_vector: number[];
 };
 ```

--- a/doc/plan/README.md
+++ b/doc/plan/README.md
@@ -2,3 +2,4 @@
 
 - 解析手法の解説: `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/doc/text-analysis-methods.md`
 - フロント向けAPI仕様: `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/doc/frontend-api-vectorize.md`
+- バックエンド辞書検索（Gemini暫定版）計画: `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/doc/plan/backend-dictionary-gemini-plan.md`


### PR DESCRIPTION
## 概要
辞書検索APIのMVPとして、`POST /dictionary/lookup` を実装しました。  
現時点では単語DBは未実装のため、Geminiへのフォールバックで用語概要を返します。

## 変更内容
- 辞書検索用のAPIエンドポイントを追加
  - `POST /dictionary/lookup`
- リクエスト/レスポンススキーマを追加
  - `DictionaryLookupRequest`
  - `DictionaryLookupResponse`
- 辞書サービスを追加
  - 用語正規化
  - DB問い合わせ（スタブ: 現在は常に `None`）
  - Gemini呼び出し
  - エラーマッピング（503/504/502）
- ルーターとOpenAPIタグを追加
  - `dictionary` タグを `/docs` に表示
- ドキュメント更新
  - Backend README に API 追記
  - `.env.example` を追加（Gemini関連設定）

## API仕様（MVP）
- エンドポイント: `POST /dictionary/lookup`
- 入力:
  - `term`（必須）
  - `context`（任意）
- 出力:
  - `term`
  - `summary`（1〜2文の日本語概要）
  - `source`（`gemini`）
  - `model`
  - `cached`（現状 `false`）

## エラー仕様
- `422`: 入力バリデーションエラー
- `503`: `GEMINI_API_KEY` 未設定
- `504`: Gemini API タイムアウト
- `502`: Gemini上流エラー/不正応答

## 変更ファイル
- `Backend/app/schemas/dictionary.py`
- `Backend/app/services/dictionary.py`
- `Backend/app/api/endpoints/dictionary.py`
- `Backend/app/api/__init__.py`
- `Backend/main.py`
- `Backend/tests/test_dictionary_service.py`
- `Backend/tests/test_dictionary_endpoint.py`
- `Backend/README.md`
- `Backend/.env.example`

## テスト
- `uv run pytest` 実行
- 追加テストを含めて全件PASS
