### PR TITLE
Feature/cloudrun dev

### DIFF
--- a/.github/workflows/deploy-backend-cloud-run.yml
+++ b/.github/workflows/deploy-backend-cloud-run.yml
@@ -1,0 +1,75 @@
+name: Deploy Backend to Cloud Run
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - "Backend/**"
+      - ".github/workflows/deploy-backend-cloud-run.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GCP_PROJECT_ID: kc3hack2026
+  GCP_REGION: asia-southeast1
+  CLOUD_RUN_SERVICE: lexiflow-backend
+  GEMINI_SECRET_NAME: gemini-api-key
+  DB_CERT_SECRET_NAME: cockroach-root-crt
+
+concurrency:
+  group: deploy-backend-cloud-run-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required secrets
+        run: |
+          if [ -z "${{ secrets.GCP_SA_KEY }}" ]; then
+            echo "::error::Repository secret GCP_SA_KEY is not set."
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Deploy Backend to Cloud Run
+        run: |
+          gcloud run deploy "${CLOUD_RUN_SERVICE}" \
+            --quiet \
+            --source "${GITHUB_WORKSPACE}/Backend" \
+            --project "${GCP_PROJECT_ID}" \
+            --region "${GCP_REGION}" \
+            --allow-unauthenticated \
+            --memory 1Gi \
+            --cpu 1 \
+            --concurrency 10 \
+            --timeout 60 \
+            --min-instances 0 \
+            --max-instances 2 \
+            --set-secrets "GEMINI_API_KEY=${GEMINI_SECRET_NAME}:latest,/root/.postgresql/root.crt=${DB_CERT_SECRET_NAME}:latest" \
+            --set-env-vars "GEMINI_MODEL=gemini-2.5-flash-lite,GEMINI_TIMEOUT_SECONDS=10,GEMINI_PARALLELISM=3,ENABLE_DB_INIT=false"
+
+      - name: Smoke test
+        run: |
+          SERVICE_URL="$(gcloud run services describe "${CLOUD_RUN_SERVICE}" --region "${GCP_REGION}" --project "${GCP_PROJECT_ID}" --format='value(status.url)')"
+          echo "Service URL: ${SERVICE_URL}"
+          curl -fsS "${SERVICE_URL}/"

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -60,6 +60,7 @@ make docker-clean
 Cloud Run へのデプロイ手順は以下を参照してください。
 
 - `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/doc/cloud-run-deploy-workflow.md`
+- 自動デプロイ Workflow: `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/.github/workflows/deploy-backend-cloud-run.yml`
 
 ## 現在の API
 

--- a/Backend/app/services/refer_dictionary.py
+++ b/Backend/app/services/refer_dictionary.py
@@ -95,7 +95,11 @@ async def _lookup_or_create(
     # 1. DB検索
     entry = None
     if db.is_available:
-        entry = await asyncio.to_thread(read_dictionary_by_term, compound_term)
+        try:
+            entry = await asyncio.to_thread(read_dictionary_by_term, compound_term)
+        except Exception:
+            logger.exception("DB検索に失敗したためLLMへフォールバック: term=%s", compound_term)
+            entry = None
 
     if entry:
         return DictionaryEntry(
@@ -125,9 +129,14 @@ async def _lookup_or_create(
                     meaning_vector=vector,
                 )
             except Exception:
-                # UNIQUE 違反 → 既に他のタスクが登録済み
-                logger.info("重複登録をスキップ: %s", compound_term)
-                entry = await asyncio.to_thread(read_dictionary_by_term, compound_term)
+                # UNIQUE 違反などで登録に失敗した場合は既存行を読み直す。
+                # 読み直しにも失敗した場合はLLM結果を返し、API全体は継続させる。
+                logger.exception("DB登録に失敗したため読み直しを試行: term=%s", compound_term)
+                try:
+                    entry = await asyncio.to_thread(read_dictionary_by_term, compound_term)
+                except Exception:
+                    logger.exception("DB再読込にも失敗したためLLM結果を返却: term=%s", compound_term)
+                    entry = None
                 if entry:
                     return DictionaryEntry(
                         term=entry.term,

--- a/Backend/tests/test_refer_dictionary_endpoint.py
+++ b/Backend/tests/test_refer_dictionary_endpoint.py
@@ -161,3 +161,34 @@ def test_refer_dictionary_db_unavailable(mock_external_services) -> None:
     mock_external_services["read"].assert_not_called()
     mock_external_services["create"].assert_not_called()
     mock_external_services["lookup"].assert_called_with("犬")
+
+
+def test_refer_dictionary_db_read_error_fallback(mock_external_services) -> None:
+    """DB readで例外が出てもLLMフォールバックで200を返す。"""
+    mock_external_services["read"].side_effect = RuntimeError("db read failed")
+
+    res = client.post("/analysis/refer_dictionary", json={"text": "犬"})
+    assert res.status_code == 200
+
+    entries = res.json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["term"] == "犬"
+    assert entries[0]["source"] == "llm"
+
+    mock_external_services["lookup"].assert_called_with("犬")
+
+
+def test_refer_dictionary_db_create_error_fallback(mock_external_services) -> None:
+    """DB createで例外が出てもLLM結果を返し500にしない。"""
+    mock_external_services["read"].return_value = None
+    mock_external_services["create"].side_effect = RuntimeError("db write failed")
+
+    res = client.post("/analysis/refer_dictionary", json={"text": "犬"})
+    assert res.status_code == 200
+
+    entries = res.json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["term"] == "犬"
+    assert entries[0]["source"] == "llm"
+
+    mock_external_services["lookup"].assert_called_with("犬")

--- a/doc/cloud-run-deploy-workflow.md
+++ b/doc/cloud-run-deploy-workflow.md
@@ -9,6 +9,7 @@ PROJECT_ID="kc3hack2026"
 REGION="asia-southeast1"
 SERVICE_NAME="lexiflow-backend"
 SECRET_NAME="gemini-api-key"
+CERT_SECRET_NAME="cockroach-root-crt"
 ```
 
 - GCP のシンガポールリージョン名は `asia-southeast1`（AWS の `ap-southeast-1` とは表記が異なる）
@@ -62,6 +63,15 @@ gcloud secrets add-iam-policy-binding "$SECRET_NAME" \
   --project "$PROJECT_ID"
 ```
 
+証明書 Secret も同様に付与:
+
+```bash
+gcloud secrets add-iam-policy-binding "$CERT_SECRET_NAME" \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor" \
+  --project "$PROJECT_ID"
+```
+
 ## 2. デプロイ（通常運用）
 
 リポジトリルート（`/Users/honmayuudai/MyHobby/hackson/KC3Hack2026`）で実行:
@@ -79,8 +89,8 @@ gcloud run deploy "$SERVICE_NAME" \
   --timeout 60 \
   --min-instances 0 \
   --max-instances 2 \
-  --set-secrets "GEMINI_API_KEY=${SECRET_NAME}:latest" \
-  --set-env-vars "GEMINI_MODEL=gemini-2.0-flash,GEMINI_TIMEOUT_SECONDS=10,GEMINI_PARALLELISM=3,ENABLE_DB_INIT=false"
+  --set-secrets "GEMINI_API_KEY=${SECRET_NAME}:latest,/root/.postgresql/root.crt=${CERT_SECRET_NAME}:latest" \
+  --set-env-vars "GEMINI_MODEL=gemini-2.5-flash-lite,GEMINI_TIMEOUT_SECONDS=10,GEMINI_PARALLELISM=3,ENABLE_DB_INIT=false"
 ```
 
 ## 3. デプロイ後の確認
@@ -110,6 +120,15 @@ gcloud run services update "$SERVICE_NAME" \
   --update-secrets "GEMINI_API_KEY=${SECRET_NAME}:latest"
 ```
 
+証明書 Secret を更新した場合:
+
+```bash
+gcloud run services update "$SERVICE_NAME" \
+  --project "$PROJECT_ID" \
+  --region "$REGION" \
+  --update-secrets "/root/.postgresql/root.crt=${CERT_SECRET_NAME}:latest"
+```
+
 ## 5. CORS（フロント本番URL）設定例
 
 `ALLOWED_ORIGINS` はカンマ区切りで指定:
@@ -136,3 +155,12 @@ gcloud secrets delete "$SECRET_NAME" \
   --project "$OLD_PROJECT_ID" \
   --quiet
 ```
+
+## 7. GitHub Actions で自動デプロイ
+
+`/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/.github/workflows/deploy-backend-cloud-run.yml` を使う場合、
+GitHub Repository Secrets に以下を登録します。
+
+- `GCP_SA_KEY`: Cloud Run デプロイ権限を持つサービスアカウント JSON キー
+
+このワークフローは `develop` / `main` への push（`Backend/**` 変更時）で自動実行されます。


### PR DESCRIPTION
## 概要
Cloud Run 本番運用に向けて、Backend の可用性とデプロイ運用を強化しました。  
主に「DB接続障害時の500回避」「Cockroach証明書運用手順の明文化」「GitHub Actions自動デプロイ追加」の3点です。

## 変更内容
- `refer_dictionary` の DB 読み取り/書き込み失敗時に LLM フォールバックするよう改善
  - `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/Backend/app/services/refer_dictionary.py`
- 上記の回帰テストを追加
  - `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/Backend/tests/test_refer_dictionary_endpoint.py`
- Cloud Run デプロイ手順に Cockroach 証明書 Secret マウント手順を追記
  - `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/doc/cloud-run-deploy-workflow.md`
- 自動デプロイ用 GitHub Actions を追加（develop/main への push + Backend 変更時）
  - `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/.github/workflows/deploy-backend-cloud-run.yml`
- Backend README に自動デプロイ Workflow 参照を追加
  - `/Users/honmayuudai/MyHobby/hackson/KC3Hack2026/Backend/README.md`

## 動作確認
- `uv run pytest -q /Users/honmayuudai/MyHobby/hackson/KC3Hack2026/Backend/tests/test_refer_dictionary_endpoint.py`  
  - `10 passed`
- Cloud Run（`kc3hack2026 / asia-southeast1`）で以下を確認
  - `OPTIONS /analysis/refer_dictionary` が CORS ヘッダ付きで `200`
  - `POST /analysis/refer_dictionary` が `500` にならず応答（DB障害時も継続可能）

## 運用メモ
- GitHub Actions 利用時は Repository Secret `GCP_SA_KEY` が必要です。
- Cloud Run 側で以下 Secret が必要です。
  - `gemini-api-key`
  - `cockroach-root-crt`（`/root/.postgresql/root.crt` にマウント）
