### PR TITLE
feat: TF-IDFバブルスコアAPI仕様を追加

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -111,6 +111,47 @@ Cloud Run へのデプロイ手順は以下を参照してください。
       "sentence_vector": [0.0312, -0.0124, 0.2011, -0.0942]
     }
     ```
+
+- `POST /analysis/tfidf/bubble-scores`
+  - 発話ごとのTF-IDFスコアから、バブルUI向けサイズを算出する
+  - 算出ロジック: `raw_score = 上位top_k語のTF-IDF合計` を `p10/p90` で正規化し、`min/max` サイズへマッピング
+  - リクエスト例:
+    ```json
+    {
+      "utterances": [
+        "今日はRAGの設計を詰めます。",
+        "APIのレイテンシ改善も必要です。",
+        "GPUコストの見積もりも確認しましょう。"
+      ],
+      "top_k": 3,
+      "window_size": 30,
+      "min_bubble_size": 28,
+      "max_bubble_size": 72
+    }
+    ```
+  - レスポンス例（抜粋）:
+    ```json
+    {
+      "meta": {
+        "algorithm": "tfidf_topk_sum_v1",
+        "p10": 0.31211,
+        "p90": 1.98212,
+        "utterance_count": 3
+      },
+      "items": [
+        {
+          "index": 0,
+          "text": "今日はRAGの設計を詰めます。",
+          "raw_score": 1.423111,
+          "normalized_score": 0.665269,
+          "bubble_size": 57,
+          "top_terms": [
+            { "term": "rag", "score": 0.845212 }
+          ]
+        }
+      ]
+    }
+    ```
   - レスポンス例（抜粋）:
     ```json
     {

--- a/Backend/app/api/endpoints/analysis.py
+++ b/Backend/app/api/endpoints/analysis.py
@@ -6,10 +6,16 @@ from app.schemas.analysis import (
     ReferDictionaryEntry,
     SentenceVectorizeRequest,
     SentenceVectorizeResponse,
+    TfidfBubbleScoresRequest,
+    TfidfBubbleScoresResponse,
     VectorizeRequest,
     VectorizeResponse,
 )
-from app.services.text_analysis import vectorize_content_tokens, vectorize_sentence
+from app.services.text_analysis import (
+    tfidf_bubble_scores,
+    vectorize_content_tokens,
+    vectorize_sentence,
+)
 from app.services.refer_dictionary import refer_dictionary
 
 router = fastapi.APIRouter()
@@ -93,6 +99,51 @@ def vectorize_sentence_endpoint(
 ) -> SentenceVectorizeResponse:
     result = vectorize_sentence(text=body.text, normalize=body.normalize)
     return SentenceVectorizeResponse(**result)
+
+
+@router.post(
+    "/tfidf/bubble-scores",
+    response_model=TfidfBubbleScoresResponse,
+    summary="発話ごとのTF-IDFスコアからバブルサイズを算出する",
+    description=(
+        "1発話=1バブルとしてTF-IDFを算出し、"
+        "上位top_k語のスコア合計を p10/p90 基準で正規化してバブルサイズに変換します。"
+    ),
+    response_description="発話ごとのTF-IDFバブルスコア",
+    responses={
+        200: {"description": "算出成功"},
+        422: {"description": "入力バリデーションエラー（空配列・空白発話など）"},
+    },
+)
+def tfidf_bubble_scores_endpoint(
+    body: TfidfBubbleScoresRequest = fastapi.Body(
+        ...,
+        examples={
+            "default": {
+                "summary": "既定パラメータで算出",
+                "value": {
+                    "utterances": [
+                        "今日はRAGの設計を詰めます。",
+                        "APIのレイテンシ改善も必要です。",
+                        "GPUコストの見積もりも確認しましょう。",
+                    ],
+                    "top_k": 3,
+                    "window_size": 30,
+                    "min_bubble_size": 28,
+                    "max_bubble_size": 72,
+                },
+            }
+        },
+    )
+) -> TfidfBubbleScoresResponse:
+    result = tfidf_bubble_scores(
+        utterances=body.utterances,
+        top_k=body.top_k,
+        window_size=body.window_size,
+        min_bubble_size=body.min_bubble_size,
+        max_bubble_size=body.max_bubble_size,
+    )
+    return TfidfBubbleScoresResponse(**result)
 
 
 @router.post(

--- a/Backend/app/schemas/analysis.py
+++ b/Backend/app/schemas/analysis.py
@@ -183,6 +183,139 @@ class SentenceVectorizeResponse(BaseModel):
     }
 
 
+class TfidfBubbleScoresRequest(BaseModel):
+    utterances: list[str] = Field(
+        min_length=1,
+        description="バブル対象の発話配列（1要素=1バブル）",
+        examples=[["今日はRAGの設計を詰めます。", "APIのレイテンシ改善も必要です。"]],
+    )
+    top_k: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="各発話で raw_score に加算する上位TF-IDF語数",
+        examples=[3],
+    )
+    window_size: int = Field(
+        default=30,
+        ge=1,
+        le=200,
+        description="TF-IDF算出に使うスライディング窓サイズ（発話数）",
+        examples=[30],
+    )
+    min_bubble_size: int = Field(
+        default=28,
+        ge=12,
+        le=200,
+        description="正規化スコア0のときの最小バブルサイズ(px)",
+        examples=[28],
+    )
+    max_bubble_size: int = Field(
+        default=72,
+        ge=12,
+        le=280,
+        description="正規化スコア1のときの最大バブルサイズ(px)",
+        examples=[72],
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "utterances": [
+                        "今日はRAGの設計を詰めます。",
+                        "APIのレイテンシ改善も必要です。",
+                        "GPUコストの見積もりも確認しましょう。",
+                    ],
+                    "top_k": 3,
+                    "window_size": 30,
+                    "min_bubble_size": 28,
+                    "max_bubble_size": 72,
+                }
+            ]
+        }
+    }
+
+    @field_validator("utterances")
+    @classmethod
+    def validate_utterances_not_blank(cls, values: list[str]) -> list[str]:
+        if not values:
+            raise ValueError("utterances must not be empty")
+        if any(not value.strip() for value in values):
+            raise ValueError("utterances must not contain blank text")
+        return values
+
+    @field_validator("max_bubble_size")
+    @classmethod
+    def validate_bubble_size_range(cls, value: int, info) -> int:
+        min_size = info.data.get("min_bubble_size")
+        if isinstance(min_size, int) and value <= min_size:
+            raise ValueError("max_bubble_size must be greater than min_bubble_size")
+        return value
+
+
+class TfidfBubbleTerm(BaseModel):
+    term: str = Field(description="TF-IDF上位語", examples=["rag"])
+    score: float = Field(description="語のTF-IDFスコア", examples=[0.845212])
+
+
+class TfidfBubbleItem(BaseModel):
+    index: int = Field(description="utterances 内のインデックス", examples=[0])
+    text: str = Field(description="対象発話テキスト")
+    raw_score: float = Field(description="上位top_k語のTF-IDF合計スコア", examples=[1.423111])
+    normalized_score: float = Field(description="p10/p90基準で0..1に正規化したスコア", examples=[0.734212])
+    bubble_size: int = Field(description="フロント表示向けの推奨バブルサイズ(px)", examples=[60])
+    top_terms: list[TfidfBubbleTerm] = Field(description="発話内のTF-IDF上位語（最大top_k件）")
+
+
+class TfidfBubbleScoresMeta(BaseModel):
+    algorithm: str = Field(description="スコア算出アルゴリズム識別子", examples=["tfidf_topk_sum_v1"])
+    top_k: int = Field(description="raw_score計算に使った上位語数", examples=[3])
+    window_size: int = Field(description="TF-IDF算出窓サイズ", examples=[30])
+    min_bubble_size: int = Field(description="最小バブルサイズ(px)", examples=[28])
+    max_bubble_size: int = Field(description="最大バブルサイズ(px)", examples=[72])
+    p10: float = Field(description="raw_score の10パーセンタイル", examples=[0.31211])
+    p90: float = Field(description="raw_score の90パーセンタイル", examples=[1.98212])
+    utterance_count: int = Field(description="入力発話数", examples=[12])
+
+
+class TfidfBubbleScoresResponse(BaseModel):
+    meta: TfidfBubbleScoresMeta = Field(description="TF-IDFバブルスコア算出のメタ情報")
+    items: list[TfidfBubbleItem] = Field(description="発話ごとのスコアと推奨バブルサイズ")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "meta": {
+                        "algorithm": "tfidf_topk_sum_v1",
+                        "top_k": 3,
+                        "window_size": 30,
+                        "min_bubble_size": 28,
+                        "max_bubble_size": 72,
+                        "p10": 0.31211,
+                        "p90": 1.98212,
+                        "utterance_count": 3,
+                    },
+                    "items": [
+                        {
+                            "index": 0,
+                            "text": "今日はRAGの設計を詰めます。",
+                            "raw_score": 1.423111,
+                            "normalized_score": 0.665269,
+                            "bubble_size": 57,
+                            "top_terms": [
+                                {"term": "rag", "score": 0.845212},
+                                {"term": "設計", "score": 0.577899},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+
 class ReferDictionaryRequest(BaseModel):
     text: str = Field(
         min_length=1,
@@ -219,4 +352,3 @@ class ReferDictionaryResponse(BaseModel):
     entries: list[ReferDictionaryEntry] = Field(
         description="辞書検索結果の一覧",
     )
-

--- a/Backend/app/services/text_analysis.py
+++ b/Backend/app/services/text_analysis.py
@@ -763,6 +763,109 @@ def top_terms_by_tfidf(corpus: list[str], top_k: int = 10) -> list[list[dict[str
     return top_terms
 
 
+def _percentile(values: list[float], quantile: float) -> float:
+    """Return interpolated percentile value in [0.0, 1.0]."""
+    if not values:
+        return 0.0
+
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+
+    position = (len(sorted_values) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return float(sorted_values[lower])
+
+    lower_value = float(sorted_values[lower])
+    upper_value = float(sorted_values[upper])
+    ratio = position - lower
+    return lower_value + (upper_value - lower_value) * ratio
+
+
+def tfidf_bubble_scores(
+    utterances: list[str],
+    top_k: int = 3,
+    window_size: int = 30,
+    min_bubble_size: int = 28,
+    max_bubble_size: int = 72,
+) -> dict[str, Any]:
+    """Calculate TF-IDF-based bubble sizes for utterance list."""
+    if not utterances:
+        return {
+            "meta": {
+                "algorithm": "tfidf_topk_sum_v1",
+                "top_k": top_k,
+                "window_size": window_size,
+                "min_bubble_size": min_bubble_size,
+                "max_bubble_size": max_bubble_size,
+                "p10": 0.0,
+                "p90": 0.0,
+                "utterance_count": 0,
+            },
+            "items": [],
+        }
+
+    cleaned = [utterance.strip() for utterance in utterances]
+    items: list[dict[str, Any]] = []
+    raw_scores: list[float] = []
+
+    # 発話 i ごとに「直近 window_size 発話」をコーパスとしてTF-IDFを算出する。
+    for i, utterance in enumerate(cleaned):
+        start = max(0, i - window_size + 1)
+        corpus = cleaned[start : i + 1]
+        current_score_map = tfidf_scores(corpus)[-1] if corpus else {}
+
+        sorted_terms = sorted(current_score_map.items(), key=lambda x: x[1], reverse=True)[:top_k]
+        raw_score = float(sum(score for _, score in sorted_terms))
+        raw_scores.append(raw_score)
+
+        items.append(
+            {
+                "index": i,
+                "text": utterance,
+                "raw_score": round(raw_score, 6),
+                "normalized_score": 0.0,
+                "bubble_size": min_bubble_size,
+                "top_terms": [
+                    {"term": term, "score": round(float(score), 6)}
+                    for term, score in sorted_terms
+                ],
+            }
+        )
+
+    p10 = _percentile(raw_scores, 0.10)
+    p90 = _percentile(raw_scores, 0.90)
+
+    # p10/p90でロバスト正規化し、0..1をバブルサイズに線形マッピングする。
+    score_width = p90 - p10
+    for item, raw_score in zip(items, raw_scores):
+        if score_width <= 0.0:
+            normalized = 0.0 if raw_score <= 0.0 else 0.5
+        else:
+            normalized = (raw_score - p10) / score_width
+            normalized = max(0.0, min(1.0, normalized))
+
+        bubble_size = int(round(min_bubble_size + (max_bubble_size - min_bubble_size) * normalized))
+        item["normalized_score"] = round(normalized, 6)
+        item["bubble_size"] = bubble_size
+
+    return {
+        "meta": {
+            "algorithm": "tfidf_topk_sum_v1",
+            "top_k": top_k,
+            "window_size": window_size,
+            "min_bubble_size": min_bubble_size,
+            "max_bubble_size": max_bubble_size,
+            "p10": round(float(p10), 6),
+            "p90": round(float(p90), 6),
+            "utterance_count": len(cleaned),
+        },
+        "items": items,
+    }
+
+
 # --- refer_dictionary 向け: 形態素解析済みトークンから直接ベクトルを算出する ---
 # morphological_analysis を再度呼ばずに済むため、
 # スレッドセーフ問題を回避しつつパフォーマンスも改善できる。
@@ -845,4 +948,3 @@ def _get_vocab_vector(nlp: Any | None, word: str) -> list[float]:
         return [float(v) for v in lexeme.vector]
 
     return []
-

--- a/Backend/tests/test_analysis_endpoint.py
+++ b/Backend/tests/test_analysis_endpoint.py
@@ -65,3 +65,42 @@ def test_vectorize_sentence_endpoint_validates_empty_text() -> None:
 def test_vectorize_sentence_endpoint_validates_whitespace_only_text() -> None:
     res = client.post("/analysis/vectorize/sentence", json={"text": "   "})
     assert res.status_code == 422
+
+
+def test_tfidf_bubble_scores_endpoint_returns_scores() -> None:
+    res = client.post(
+        "/analysis/tfidf/bubble-scores",
+        json={
+            "utterances": [
+                "今日はRAG設計を進めます。",
+                "APIのレイテンシを改善します。",
+                "GPUコストの見積もりを確認します。",
+            ],
+            "top_k": 3,
+            "window_size": 30,
+            "min_bubble_size": 28,
+            "max_bubble_size": 72,
+        },
+    )
+    assert res.status_code == 200
+    body = res.json()
+
+    assert "meta" in body
+    assert body["meta"]["algorithm"] == "tfidf_topk_sum_v1"
+    assert body["meta"]["utterance_count"] == 3
+    assert len(body["items"]) == 3
+    assert all(28 <= item["bubble_size"] <= 72 for item in body["items"])
+
+
+def test_tfidf_bubble_scores_endpoint_validates_blank_utterance() -> None:
+    res = client.post(
+        "/analysis/tfidf/bubble-scores",
+        json={
+            "utterances": ["有効な発話です", "   "],
+            "top_k": 3,
+            "window_size": 30,
+            "min_bubble_size": 28,
+            "max_bubble_size": 72,
+        },
+    )
+    assert res.status_code == 422

--- a/Backend/tests/test_text_analysis_service.py
+++ b/Backend/tests/test_text_analysis_service.py
@@ -2,6 +2,7 @@ import app.services.text_analysis as text_analysis
 from app.services.text_analysis import (
     dependency_parse,
     morphological_analysis,
+    tfidf_bubble_scores,
     tfidf_scores,
     top_terms_by_tfidf,
     vectorize_content_tokens,
@@ -164,3 +165,39 @@ def test_vectorize_sentence_hash_fallback_honors_normalize_flag(monkeypatch) -> 
     assert raw["sentence_vector"] != normalized["sentence_vector"]
     assert raw_norm > 1.0
     assert abs(normalized_norm - 1.0) < 1e-6
+
+
+def test_tfidf_bubble_scores_returns_per_utterance_scores() -> None:
+    result = tfidf_bubble_scores(
+        utterances=[
+            "今日はRAG設計を進めます。",
+            "RAG設計のレビューをします。",
+            "GPUメモリの見積もりを更新します。",
+        ],
+        top_k=2,
+        window_size=3,
+        min_bubble_size=24,
+        max_bubble_size=60,
+    )
+
+    assert result["meta"]["algorithm"] == "tfidf_topk_sum_v1"
+    assert result["meta"]["utterance_count"] == 3
+    assert len(result["items"]) == 3
+    assert all(0.0 <= item["normalized_score"] <= 1.0 for item in result["items"])
+    assert all(24 <= item["bubble_size"] <= 60 for item in result["items"])
+
+
+def test_tfidf_bubble_scores_exposes_top_terms_for_each_utterance() -> None:
+    result = tfidf_bubble_scores(
+        utterances=[
+            "API API API",
+            "API API API",
+            "量子耐性暗号の検証を進める",
+        ],
+        top_k=2,
+        window_size=3,
+    )
+
+    assert result["items"][2]["raw_score"] > 0.0
+    assert len(result["items"][2]["top_terms"]) > 0
+    assert all(term["term"] != "api" for term in result["items"][2]["top_terms"])

--- a/doc/frontend-api-vectorize.md
+++ b/doc/frontend-api-vectorize.md
@@ -18,6 +18,8 @@
   - 単語（内容語）ベクトルを返す
 - `POST /analysis/vectorize/sentence`
   - 文章全体の単一ベクトルを返す
+- `POST /analysis/tfidf/bubble-scores`
+  - 発話ごとのTF-IDFスコアと推奨バブルサイズを返す
 - 共通: `Content-Type: application/json`
 
 ## 3. リクエスト
@@ -226,5 +228,116 @@ export type SentenceVectorizeResponse = {
     content_token_count: number;
   };
   sentence_vector: number[];
+};
+```
+
+## 8. TF-IDF バブルスコアAPI（`/analysis/tfidf/bubble-scores`）
+
+### 8.1 リクエスト
+
+```json
+{
+  "utterances": [
+    "今日はRAGの設計を詰めます。",
+    "APIのレイテンシ改善も必要です。",
+    "GPUコストの見積もりも確認しましょう。"
+  ],
+  "top_k": 3,
+  "window_size": 30,
+  "min_bubble_size": 28,
+  "max_bubble_size": 72
+}
+```
+
+| 項目              | 型         | 必須 | 既定値 | 説明                                                |
+| ----------------- | ---------- | ---- | ------ | --------------------------------------------------- |
+| `utterances`      | `string[]` | 必須 | -      | バブル対象の発話配列（1要素=1バブル）              |
+| `top_k`           | `number`   | 任意 | `3`    | `raw_score` に加算する上位TF-IDF語数               |
+| `window_size`     | `number`   | 任意 | `30`   | TF-IDF算出に使うスライディング窓サイズ（発話数）   |
+| `min_bubble_size` | `number`   | 任意 | `28`   | 正規化スコア0のときの最小バブルサイズ(px)          |
+| `max_bubble_size` | `number`   | 任意 | `72`   | 正規化スコア1のときの最大バブルサイズ(px)          |
+
+補足:
+
+- 空配列、空白のみ発話、`max_bubble_size <= min_bubble_size` は `422` になります。
+
+### 8.2 レスポンス
+
+```jsonc
+{
+  "meta": {
+    "algorithm": "tfidf_topk_sum_v1",
+    "top_k": 3,
+    "window_size": 30,
+    "min_bubble_size": 28,
+    "max_bubble_size": 72,
+    "p10": 0.31211,
+    "p90": 1.98212,
+    "utterance_count": 3
+  },
+  "items": [
+    {
+      "index": 0,
+      "text": "今日はRAGの設計を詰めます。",
+      "raw_score": 1.423111,
+      "normalized_score": 0.665269,
+      "bubble_size": 57,
+      "top_terms": [
+        { "term": "rag", "score": 0.845212 },
+        { "term": "設計", "score": 0.577899 }
+      ]
+    }
+  ]
+}
+```
+
+| 項目                     | 型         | 説明                                                          |
+| ------------------------ | ---------- | ------------------------------------------------------------- |
+| `meta.algorithm`         | `string`   | 算出アルゴリズム識別子（現状: `tfidf_topk_sum_v1`）          |
+| `meta.p10` / `meta.p90` | `number`   | `raw_score` の正規化に使った分位点                            |
+| `meta.utterance_count`   | `number`   | 入力発話数                                                    |
+| `items[]`                | `object[]` | 発話ごとのバブルスコア                                        |
+| `items[].index`          | `number`   | `utterances` 内の位置                                         |
+| `items[].text`           | `string`   | 対象発話（そのまま返却）                                      |
+| `items[].raw_score`      | `number`   | 上位 `top_k` 語のTF-IDF合計スコア                             |
+| `items[].normalized_score` | `number` | `p10/p90` 正規化後の 0..1 スコア                              |
+| `items[].bubble_size`    | `number`   | 推奨バブルサイズ(px)                                           |
+| `items[].top_terms`      | `object[]` | 発話内のTF-IDF上位語（最大 `top_k` 件）                       |
+| `items[].top_terms[].term` | `string` | 上位語                                                        |
+| `items[].top_terms[].score` | `number` | 上位語のTF-IDFスコア                                          |
+
+### 8.3 TypeScript 型サンプル
+
+```ts
+export type TfidfBubbleScoresRequest = {
+  utterances: string[];
+  top_k?: number;
+  window_size?: number;
+  min_bubble_size?: number;
+  max_bubble_size?: number;
+};
+
+export type TfidfBubbleScoresResponse = {
+  meta: {
+    algorithm: "tfidf_topk_sum_v1" | string;
+    top_k: number;
+    window_size: number;
+    min_bubble_size: number;
+    max_bubble_size: number;
+    p10: number;
+    p90: number;
+    utterance_count: number;
+  };
+  items: Array<{
+    index: number;
+    text: string;
+    raw_score: number;
+    normalized_score: number;
+    bubble_size: number;
+    top_terms: Array<{
+      term: string;
+      score: number;
+    }>;
+  }>;
 };
 ```


### PR DESCRIPTION
## 概要
会話バブルUIで使うために、発話ごとのTF-IDFスコアを算出し、表示サイズに変換するAPIを追加しました。  
`1発話 = 1バブル` を前提に、`raw_score -> 正規化 -> bubble_size(px)` を返します。

## 追加したもの
- 新規API: `POST /analysis/tfidf/bubble-scores`
- サービスロジック:
  - `raw_score = 上位top_k語のTF-IDF合計`
  - `p10/p90` によるロバスト正規化
  - `min_bubble_size ~ max_bubble_size` への線形マッピング
- スキーマ:
  - Request/Responseモデル追加
  - バリデーション追加（空配列、空白発話、`max_bubble_size <= min_bubble_size` を422）
- テスト:
  - サービステスト追加
  - エンドポイントテスト追加
- ドキュメント:
  - Backend README更新
  - フロント向けAPI仕様更新（リクエスト/レスポンス/TS型）

## API仕様（要点）
### Request
- `utterances: string[]`（必須）
- `top_k?: number`（default: `3`）
- `window_size?: number`（default: `30`）
- `min_bubble_size?: number`（default: `28`）
- `max_bubble_size?: number`（default: `72`）

### Response
- `meta`: `algorithm`, `top_k`, `window_size`, `p10`, `p90`, `utterance_count` など
- `items[]`:
  - `index`, `text`
  - `raw_score`
  - `normalized_score`（0..1）
  - `bubble_size`（px）
  - `top_terms[]`

## アルゴリズム意図
- 突発的な高スコア語に引きずられすぎないよう、min-maxではなく`p10/p90`で正規化
- フロントは `bubble_size` をそのまま使えるため、描画実装がシンプル

## テスト結果
- `uv run pytest -q tests/test_text_analysis_service.py tests/test_analysis_endpoint.py`
- `21 passed`

## 互換性
- 既存APIへの破壊的変更なし（新規エンドポイント追加のみ）

## レビュー観点
- `p10/p90` 正規化の妥当性（会話長やドメインでの安定性）
- `top_k/window_size/min-max` デフォルト値の妥当性
- フロントでのバブルサイズ運用（そのまま採用 or 追加平滑化）